### PR TITLE
remove console.log()

### DIFF
--- a/assets/plugin.js
+++ b/assets/plugin.js
@@ -47,9 +47,7 @@ require(['gitbook', 'jQuery'], function(gitbook, $) {
     }
 
     if (lines.length > 1) {
-      console.log(lines);
       lines = lines.map(line => '<span class="code-line">' + line + '</span>');
-      console.log(lines);
       code.html(lines.join('\n'));
     }
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "main": "index.js",
   "license": "MIT",
   "homepage": "https://github.com/davidmogar/gitbook-plugin-code",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "author": {
     "name": "David Moreno-García",
     "email": "david.mogar@gmail.com"


### PR DESCRIPTION
The `console.log()` is redundant when using a production environment,it would be better to remove it